### PR TITLE
removed superfluous slash from base_url

### DIFF
--- a/app/Libraries/GroceryCrud.php
+++ b/app/Libraries/GroceryCrud.php
@@ -1971,24 +1971,24 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 
     public function set_css($css_file)
     {
-        $this->css_files[sha1($css_file)] = base_url(). '/' . $css_file;
+        $this->css_files[sha1($css_file)] = base_url() . $css_file;
     }
 
     public function set_js($js_file)
     {
-        $this->js_files[sha1($js_file)] = base_url(). '/' .$js_file;
+        $this->js_files[sha1($js_file)] = base_url() .$js_file;
     }
 
     public function set_js_lib($js_file)
     {
-        $this->js_lib_files[sha1($js_file)] = base_url(). '/' .$js_file;
-        $this->js_files[sha1($js_file)] = base_url(). '/' .$js_file;
+        $this->js_lib_files[sha1($js_file)] = base_url() .$js_file;
+        $this->js_files[sha1($js_file)] = base_url() .$js_file;
     }
 
     public function set_js_config($js_file)
     {
-        $this->js_config_files[sha1($js_file)] = base_url(). '/' .$js_file;
-        $this->js_files[sha1($js_file)] = base_url(). '/' .$js_file;
+        $this->js_config_files[sha1($js_file)] = base_url() .$js_file;
+        $this->js_files[sha1($js_file)] = base_url() .$js_file;
     }
 
     public function is_IE7()
@@ -2062,11 +2062,11 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
         {
             /** Initialize JavaScript variables */
             $js_vars =  array(
-                'default_javascript_path'	=> base_url() . '/' . $this->default_javascript_path,
-                'default_css_path'			=> base_url() . '/' . $this->default_css_path,
-                'default_texteditor_path'	=> base_url() . '/' . $this->default_texteditor_path,
-                'default_theme_path'		=> base_url() . '/' . $this->default_theme_path,
-                'base_url'				 	=> base_url() . '/'
+                'default_javascript_path'	=> base_url() . $this->default_javascript_path,
+                'default_css_path'			=> base_url() . $this->default_css_path,
+                'default_texteditor_path'	=> base_url() . $this->default_texteditor_path,
+                'default_theme_path'		=> base_url() . $this->default_theme_path,
+                'base_url'				 	=> base_url()
             );
             $this->_add_js_vars($js_vars);
 


### PR DESCRIPTION
Hi John

In one of the recent version of Codeigniter base_url() and uri_string() functions were touched.

https://codeigniter.com/user_guide/installation/upgrade_432.html

Now they are not returning the trailing slash. I have updated base_url() in the library but can you check if it won't affect anything I'm not aware of?

Also there were a lot of different breaking changes during the upgrade up to CI 4.3.2, do you think GC will work with the latest CI version? Up to which CI version GC is compatible?