### PR TITLE
Update GroceryCrud.php

### DIFF
--- a/app/Libraries/GroceryCrud.php
+++ b/app/Libraries/GroceryCrud.php
@@ -3442,9 +3442,9 @@ class GroceryCrud extends grocery_CRUD_States
     protected $default_css_path			= null; //autogenerate, please do not modify
     protected $default_texteditor_path 	= null; //autogenerate, please do not modify
     protected $default_theme_path		= null; //autogenerate, please do not modify
-    protected $default_language_path	= 'assets/grocery_crud/languages';
-    protected $default_config_path		= 'assets/grocery_crud/config';
-    protected $default_assets_path		= 'assets/grocery_crud';
+    protected $default_language_path	= 'public/assets/grocery_crud/languages';
+    protected $default_config_path		= 'public/assets/grocery_crud/config';
+    protected $default_assets_path		= 'public/assets/grocery_crud';
 
     /**
      *


### PR DESCRIPTION
Wrong path in line 3445-3447, update path from `assets/grocery_crud` to `public/assets/grocery_crud`
``` php
$default_language_path	= 'public/assets/grocery_crud/languages';
$default_config_path	= 'public/assets/grocery_crud/config';
$default_assets_path	= 'public/assets/grocery_crud';
```

In codeigniter 4, all assets put on the `public/*` directory

, 